### PR TITLE
Return value of nl_checkout_fields_priority was too high so when Chec…

### DIFF
--- a/assets/css/nl-checkout.css
+++ b/assets/css/nl-checkout.css
@@ -22,3 +22,58 @@
 #billing_house_number, #shipping_house_number {
 	-moz-appearance: textfield;
 }
+
+#billing_address_1_field, #shipping_address_1_field, #shipping_address_2_field{
+	display:none;
+}
+
+#billing_house_number_field, #billing_house_number_suffix_field, #billing_postcode_field,
+#billing_street_name_field, #billing_city_field{
+	overflow:visible;
+	float:none;
+	display:inline-block;
+	vertical-align:top;
+}
+
+#billing_street_name_field{
+	width:calc(66% - 24px);
+	margin-right:10px !important;
+}
+
+#billing_house_number_field, #billing_house_number_suffix_field, #billing_postcode_field{
+	width:calc(22% - 24px);
+}
+
+#billing_house_number_suffix_field{
+	margin-right:0 !important;
+}
+
+#billing_city_field{
+	width:calc(88% - 38px);
+}
+
+#shipping_house_number_field, #shipping_house_number_suffix_field, #shipping_postcode_field,
+#shipping_street_name_field, #shipping_city_field{
+	overflow:visible;
+	float:none;
+	display:inline-block;
+	vertical-align:top;
+}
+
+#shipping_street_name_field{
+	width:calc(66% - 24px);
+	margin-right:10px !important;
+}
+
+#shipping_house_number_field, #shipping_house_number_suffix_field, #shipping_postcode_field{
+	width:calc(22% - 24px);
+	margin-right:10px !important;
+}
+
+#shipping_house_number_suffix_field{
+	margin-right:0 !important;
+}
+
+#shipping_city_field{
+	width:calc(88% - 38px);
+}

--- a/includes/class-wcmp-nlpostcode-fields.php
+++ b/includes/class-wcmp-nlpostcode-fields.php
@@ -24,7 +24,7 @@ class WC_NLPostcode_Fields {
 		// when Checkout Field Editor is active
 		if ( function_exists('thwcfd_is_locale_field') || function_exists('wc_checkout_fields_modify_billing_fields') ) {
 			add_filter( 'nl_checkout_fields_priority', function(){
-				return 1001;
+				return 10;
 			} );
 		}
 


### PR DESCRIPTION
Return value of nl_checkout_fields_priority was too high so when Checkout Field Editor for WooCommerce was activated so address fields would not be replaced but be prepended. 

Also hide the default fields when needed and some small styling issues.