### PR TITLE
fix: error messages for international shipment

### DIFF
--- a/includes/admin/OrderSettingsRows.php
+++ b/includes/admin/OrderSettingsRows.php
@@ -77,9 +77,9 @@ class OrderSettingsRows
         AbstractDeliveryOptionsAdapter $deliveryOptions,
         WC_Order $order
     ): array {
-        $orderSettings = new OrderSettings($deliveryOptions, $order);
-        $isHomeCountry = WCPN_Data::isHomeCountry($order->get_shipping_country());
-        $packageTypeOptions   = array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman());
+        $orderSettings      = new OrderSettings($deliveryOptions, $order);
+        $isHomeCountry      = WCPN_Data::isHomeCountry($order->get_shipping_country());
+        $packageTypeOptions = array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman());
 
         // Remove mailbox because this is not possible for international shipments
         if (! $isHomeCountry){

--- a/includes/admin/OrderSettingsRows.php
+++ b/includes/admin/OrderSettingsRows.php
@@ -77,11 +77,14 @@ class OrderSettingsRows
         AbstractDeliveryOptionsAdapter $deliveryOptions,
         WC_Order $order
     ): array {
-        $orderSettings           = new OrderSettings($deliveryOptions, $order);
-        $isHomeCountry           = WCPN_Data::isHomeCountry($order->get_shipping_country());
-        $isEuCountry             = WCPN_Country_Codes::isEuCountry($order->get_shipping_country());
-        $hasMultiplePackageTypes = count(WCPN_Data::getPackageTypes()) > 1;
-        $isPackageTypeDisabled   = ! $hasMultiplePackageTypes || $deliveryOptions->isPickup() || ! $isHomeCountry;
+        $orderSettings = new OrderSettings($deliveryOptions, $order);
+        $isHomeCountry = WCPN_Data::isHomeCountry($order->get_shipping_country());
+        $packageType   = array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman());
+
+        // Remove mailbox because this is not possible for international shipments
+        if (! $isHomeCountry){
+            unset($packageType['mailbox']);
+        }
 
         $rows = [
             [
@@ -104,9 +107,8 @@ class OrderSettingsRows
                 "name"              => self::OPTION_PACKAGE_TYPE,
                 "label"             => __("Shipment type", "woocommerce-postnl"),
                 "type"              => "select",
-                "options"           => array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman()),
+                "options"           => $packageType,
                 "value"             => WCPOST()->export->getPackageTypeFromOrder($order, $deliveryOptions),
-                "custom_attributes" => [],
             ],
         ];
 

--- a/includes/admin/OrderSettingsRows.php
+++ b/includes/admin/OrderSettingsRows.php
@@ -79,11 +79,11 @@ class OrderSettingsRows
     ): array {
         $orderSettings = new OrderSettings($deliveryOptions, $order);
         $isHomeCountry = WCPN_Data::isHomeCountry($order->get_shipping_country());
-        $packageType   = array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman());
+        $packageTypeOptions   = array_combine(WCPN_Data::getPackageTypes(), WCPN_Data::getPackageTypesHuman());
 
         // Remove mailbox because this is not possible for international shipments
         if (! $isHomeCountry){
-            unset($packageType['mailbox']);
+            unset($packageTypeOptions['mailbox']);
         }
 
         $rows = [
@@ -107,7 +107,7 @@ class OrderSettingsRows
                 "name"              => self::OPTION_PACKAGE_TYPE,
                 "label"             => __("Shipment type", "woocommerce-postnl"),
                 "type"              => "select",
-                "options"           => $packageType,
+                "options"           => $packageTypeOptions,
                 "value"             => WCPOST()->export->getPackageTypeFromOrder($order, $deliveryOptions),
             ],
         ];

--- a/includes/admin/class-wcpost-admin.php
+++ b/includes/admin/class-wcpost-admin.php
@@ -1030,7 +1030,6 @@ class WCPOST_Admin
     {
         $data['package_type'] = $data['package_type'] ?? AbstractConsignment::DEFAULT_PACKAGE_TYPE_NAME;
         $isHomeCountry        = WCPN_Data::isHomeCountry($country);
-        $isEuCountry          = WCPN_Country_Codes::isEuCountry($country);
 
         if (! $isHomeCountry) {
             $data['package_type'] = AbstractConsignment::DEFAULT_PACKAGE_TYPE_NAME;

--- a/includes/vendor/myparcelnl/sdk/src/Services/ConsignmentEncode.php
+++ b/includes/vendor/myparcelnl/sdk/src/Services/ConsignmentEncode.php
@@ -291,12 +291,12 @@ class ConsignmentEncode
             throw new MissingFieldException('Product data must be set for international MyParcel shipments. Use addItem().');
         }
 
-        if ($consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_PACKAGE) {
-            throw new MissingFieldException('For international shipments, package_type must be 1 (normal package).');
+        if ($consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_PACKAGE && $consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_LETTER) {
+            throw new MissingFieldException('For international shipments, package_type must be 1 (normal package) or 3 (letter).');
         }
 
-        if (empty($consignment->getLabelDescription())) {
-            throw new MissingFieldException('Label description/invoice id is required for international shipments. Use getLabelDescription().');
+        if (empty($consignment->getInvoice())) {
+            throw new MissingFieldException('Invoice id is required for international shipments. Use setInvoice().');
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Plugin Name ===
 Contributors: richardperdaan, ademdemir, edielemoine
-Tags: woocommerce, export, delivery, packages, postnl, flespakket, postnl
+Tags: woocommerce, export, delivery, packages, Postnl, postnl
 Requires at least: 3.5.1 & WooCommerce 2.0+
-Tested up to: 5.5.1
+Tested up to: 5.6.0
 Stable tag: trunk
 Requires PHP: 7.1
 License: GPLv3 or later
@@ -89,6 +89,9 @@ function wcpostnl_new_email_text($track_trace_tekst) {
 5. PostNL information on the order details page
 
 == Changelog ==
+
+= 4.0.2 (--) =
+* Fix: Export letter for international shipments
 
 = 4.0.1 (2021-01-06) =
 * Fix: Auto export when order is paid

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Plugin Name ===
 Contributors: richardperdaan, ademdemir, edielemoine
-Tags: woocommerce, export, delivery, packages, Postnl, postnl
+Tags: woocommerce, export, delivery, packages, postnl
 Requires at least: 3.5.1 & WooCommerce 2.0+
 Tested up to: 5.6.0
 Stable tag: trunk

--- a/woocommerce-postnl.php
+++ b/woocommerce-postnl.php
@@ -5,7 +5,7 @@ Plugin URI: https://postnl.nl/
 Description: Export your WooCommerce orders to PostNL (https://postnl.nl/) and print labels directly from the WooCommerce admin
 Author: PostNL
 Author URI: https://postnl.nl
-Version: 4.0.1
+Version: 4.0.2
 Text Domain: woocommerce-postnl
 
 License: GPLv3 or later
@@ -28,7 +28,7 @@ if (! class_exists('WCPOST')) :
         const MINIMUM_PHP_VERSION_5_4 = '5.4';
         const PHP_VERSION_7_1         = '7.1';
 
-        public $version = '4.0.1';
+        public $version = '4.0.2';
 
         public $plugin_basename;
 


### PR DESCRIPTION
It is also possible to send letters for an international shipment and a label description is not required, but an invoice is required.
